### PR TITLE
fix: GitHub Actions Secret 이름 통일

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: scripts
         env:
           ADVENOH_STATUS_SUPABASE_URL: ${{ secrets.ADVENOH_STATUS_SUPABASE_URL }}
-          ADVENOH_STATUS_SUPABASE_API_KEY: ${{ secrets.ADVENOH_STATUS_SUPABASE_SERVICE_KEY }}
+          ADVENOH_STATUS_SUPABASE_API_KEY: ${{ secrets.ADVENOH_STATUS_SUPABASE_API_KEY }}
           ADVENOH_STATUS_SLACK_BOT_TOKEN: ${{ secrets.ADVENOH_STATUS_SLACK_BOT_TOKEN }}
           ADVENOH_STATUS_SLACK_CHANNEL_ID: ${{ secrets.ADVENOH_STATUS_SLACK_CHANNEL_ID }}
         run: uv run python health_check.py


### PR DESCRIPTION
- ADVENOH_STATUS_SUPABASE_SERVICE_KEY -> ADVENOH_STATUS_SUPABASE_API_KEY
- 환경변수 이름과 Secret 이름 일치

Related to #10
