### PR TITLE
fix: upgrade Next.js to 16.0.7 for CVE-2025-66478 security patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,153 @@
-# advenoh-status
+# Advenoh Status
+
+시스템 서버 모니터링 서비스 - GitHub Actions에서 서비스 상태를 체크하고, Supabase에 저장하며, Netlify에서 정적 웹사이트로 표시합니다.
+
+## 아키텍처
+
+```
+GitHub Actions (매시간 Cron) → Supabase PostgreSQL → Netlify (정적 웹)
+                                     ↓
+                            Slack 알림 (상태 변경 시)
+```
+
+## 기술 스택
+
+| 영역 | 기술 |
+|------|------|
+| Frontend | Next.js 16, React 19, Tailwind CSS v4, TypeScript |
+| Database | Supabase PostgreSQL (RLS 적용) |
+| Health Check | Python 3.12+, httpx, slack_sdk |
+| Hosting | Netlify (ISR 지원) |
+| CI/CD | GitHub Actions |
+
+## 주요 기능
+
+- **Dashboard**: 서비스 상태 실시간 모니터링, 90일 업타임 그리드
+- **History**: 6개월 월별 캘린더 뷰
+- **Slack 알림**: 상태 변경 시 자동 알림 (WARN/ERROR)
+- **상태 판정**:
+  - `OK`: HTTP 200 & 응답시간 < threshold (기본 3000ms)
+  - `WARN`: HTTP 200 & 응답시간 > threshold
+  - `ERROR`: HTTP 4xx/5xx 또는 타임아웃
+
+## 프로젝트 구조
+
+```
+advenoh-status/
+├── .github/workflows/
+│   └── health-check.yml      # 매시간 헬스 체크 실행
+├── scripts/
+│   ├── health_check.py       # Python 헬스 체크 스크립트
+│   └── pyproject.toml        # Python 의존성
+├── src/
+│   ├── app/                  # Next.js App Router
+│   │   ├── page.tsx          # 메인 대시보드
+│   │   └── history/          # 업타임 히스토리
+│   ├── components/           # React 컴포넌트
+│   │   ├── Dashboard.tsx
+│   │   ├── UptimeGrid.tsx    # 90일 그리드 (CSS Grid)
+│   │   └── MonthlyCalendar.tsx
+│   ├── hooks/
+│   │   └── useServices.ts    # 데이터 조회 훅
+│   └── lib/
+│       ├── supabase.ts       # Supabase 클라이언트
+│       └── dateUtils.ts      # 날짜 유틸리티
+├── supabase/migrations/      # DB 스키마
+└── netlify.toml              # Netlify 설정
+```
+
+## 시작하기
+
+### 사전 요구사항
+
+- Node.js 18+
+- Python 3.12+ (헬스 체크용)
+- [uv](https://github.com/astral-sh/uv) (Python 패키지 관리)
+
+### 설치
+
+```bash
+# Frontend 의존성 설치
+npm install
+
+# Python 의존성 설치
+cd scripts
+uv sync
+```
+
+### 환경 변수 설정
+
+```bash
+# .env.local (Frontend)
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# GitHub Actions Secrets
+ADVENOH_STATUS_SUPABASE_URL=your_supabase_url
+ADVENOH_STATUS_SUPABASE_API_KEY=your_service_role_key
+ADVENOH_STATUS_SLACK_BOT_TOKEN=xoxb-...  # 선택사항
+ADVENOH_STATUS_SLACK_CHANNEL_ID=C...     # 선택사항
+```
+
+### 개발 서버 실행
+
+```bash
+npm run dev
+```
+
+http://localhost:3000 에서 확인
+
+### 빌드
+
+```bash
+npm run build
+```
+
+### 헬스 체크 수동 실행
+
+```bash
+cd scripts
+uv run python health_check.py
+```
+
+## 데이터베이스 스키마
+
+```sql
+-- services: 모니터링 대상 서비스
+CREATE TABLE services (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  threshold_ms INT DEFAULT 3000
+);
+
+-- service_status_logs: 상태 로그
+CREATE TABLE service_status_logs (
+  id BIGSERIAL PRIMARY KEY,
+  service_id UUID REFERENCES services(id),
+  timestamp TIMESTAMPTZ DEFAULT now(),
+  status TEXT CHECK (status IN ('OK', 'WARN', 'ERROR')),
+  response_time INT,
+  http_status INT,
+  message TEXT
+);
+```
+
+## 스크립트
+
+```bash
+npm run dev       # 개발 서버
+npm run build     # 프로덕션 빌드
+npm run lint      # ESLint 검사
+npm run test      # Playwright 테스트
+npm run test:ui   # Playwright UI 모드
+```
+
+## 배포
+
+- **Frontend**: Netlify에 자동 배포 (main 브랜치 push 시)
+- **Health Check**: GitHub Actions에서 매시간 자동 실행
+
+## 라이선스
+
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.86.0",
-        "next": "^16.0.6",
+        "next": "16.0.7",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.6.tgz",
-      "integrity": "sha512-PFTK/G/vM3UJwK5XDYMFOqt8QW42mmhSgdKDapOlCqBUAOfJN2dyOnASR/xUR/JRrro0pLohh/zOJ77xUQWQAg==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.7.tgz",
+      "integrity": "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.6.tgz",
-      "integrity": "sha512-AGzKiPlDiui+9JcPRHLI4V9WFTTcKukhJTfK9qu3e0tz+Y/88B7vo5yZoO7UaikplJEHORzG3QaBFQfkjhnL0Q==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.7.tgz",
+      "integrity": "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg==",
       "cpu": [
         "arm64"
       ],
@@ -1094,9 +1094,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.6.tgz",
-      "integrity": "sha512-LlLLNrK9WCIUkq2GciWDcquXYIf7vLxX8XE49gz7EncssZGL1vlHwgmURiJsUZAvk0HM1a8qb1ABDezsjAE/jw==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.7.tgz",
+      "integrity": "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA==",
       "cpu": [
         "x64"
       ],
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.6.tgz",
-      "integrity": "sha512-r04NzmLSGGfG8EPXKVK72N5zDNnq9pa9el78LhdtqIC3zqKh74QfKHnk24DoK4PEs6eY7sIK/CnNpt30oc59kg==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.7.tgz",
+      "integrity": "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==",
       "cpu": [
         "arm64"
       ],
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.6.tgz",
-      "integrity": "sha512-hfB/QV0hA7lbD1OJxp52wVDlpffUMfyxUB5ysZbb/pBC5iuhyLcEKSVQo56PFUUmUQzbMsAtUu6k2Gh9bBtWXA==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.7.tgz",
+      "integrity": "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==",
       "cpu": [
         "arm64"
       ],
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.6.tgz",
-      "integrity": "sha512-PZJushBgfvKhJBy01yXMdgL+l5XKr7uSn5jhOQXQXiH3iPT2M9iG64yHpPNGIKitKrHJInwmhPVGogZBAJOCPw==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.7.tgz",
+      "integrity": "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==",
       "cpu": [
         "x64"
       ],
@@ -1158,9 +1158,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.6.tgz",
-      "integrity": "sha512-LqY76IojrH9yS5fyATjLzlOIOgwyzBuNRqXwVxcGfZ58DWNQSyfnLGlfF6shAEqjwlDNLh4Z+P0rnOI87Y9jEw==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.7.tgz",
+      "integrity": "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==",
       "cpu": [
         "x64"
       ],
@@ -1174,9 +1174,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.6.tgz",
-      "integrity": "sha512-eIfSNNqAkj0tqKRf0u7BVjqylJCuabSrxnpSENY3YKApqwDMeAqYPmnOwmVe6DDl3Lvkbe7cJAyP6i9hQ5PmmQ==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.7.tgz",
+      "integrity": "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.6.tgz",
-      "integrity": "sha512-QGs18P4OKdK9y2F3Th42+KGnwsc2iaThOe6jxQgP62kslUU4W+g6AzI6bdIn/pslhSfxjAMU5SjakfT5Fyo/xA==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.7.tgz",
+      "integrity": "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug==",
       "cpu": [
         "x64"
       ],
@@ -5187,12 +5187,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.6.tgz",
-      "integrity": "sha512-2zOZ/4FdaAp5hfCU/RnzARlZzBsjaTZ/XjNQmuyYLluAPM7kcrbIkdeO2SL0Ysd1vnrSgU+GwugfeWX1cUCgCg==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
+      "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.6",
+        "@next/env": "16.0.7",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5205,14 +5205,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.6",
-        "@next/swc-darwin-x64": "16.0.6",
-        "@next/swc-linux-arm64-gnu": "16.0.6",
-        "@next/swc-linux-arm64-musl": "16.0.6",
-        "@next/swc-linux-x64-gnu": "16.0.6",
-        "@next/swc-linux-x64-musl": "16.0.6",
-        "@next/swc-win32-arm64-msvc": "16.0.6",
-        "@next/swc-win32-x64-msvc": "16.0.6",
+        "@next/swc-darwin-arm64": "16.0.7",
+        "@next/swc-darwin-x64": "16.0.7",
+        "@next/swc-linux-arm64-gnu": "16.0.7",
+        "@next/swc-linux-arm64-musl": "16.0.7",
+        "@next/swc-linux-x64-gnu": "16.0.7",
+        "@next/swc-linux-x64-musl": "16.0.7",
+        "@next/swc-win32-arm64-msvc": "16.0.7",
+        "@next/swc-win32-x64-msvc": "16.0.7",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.86.0",
-    "next": "^16.0.6",
+    "next": "16.0.7",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },


### PR DESCRIPTION
## Summary

- Next.js 16.0.6 → 16.0.7 업그레이드 (CVE-2025-66478 보안 취약점 패치)
- README.md 문서 추가 (프로젝트 구조, 기술 스택, 시작 가이드)

## 변경 파일
- `package.json` - Next.js 버전 업그레이드
- `package-lock.json` - 의존성 업데이트
- `README.md` - 프로젝트 문서 추가

## 보안 취약점 정보
- **CVE-2025-66478**: React Server Components의 보안 취약점
- Netlify가 해당 취약점이 있는 버전의 배포를 차단
- 공식 도구 `npx fix-react2shell-next --fix`로 패치 적용

## Test plan
- [x] `npm run build` 빌드 성공 확인
- [x] Next.js 16.0.7로 정상 업그레이드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)