### PR TITLE
fix: Supabase 기본 limit 1000으로 인한 최신 데이터 누락 버그 수정

### DIFF
--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -78,7 +78,8 @@ export function useUptimeData(days: number = 90) {
           services:service_id (name, url)
         `)
         .gte('timestamp', startDate.toISOString())
-        .order('timestamp', { ascending: true });
+        .order('timestamp', { ascending: false })
+        .limit(10000);  // Supabase 기본 limit 1000 → 10000으로 확장
 
       const logsData = (logs as ServiceStatusLogWithService[]) || [];
 


### PR DESCRIPTION
## Summary

- Dashboard/History 페이지에서 12/27, 12/28 데이터가 회색(No data)으로 표시되는 버그 수정
- **원인**: Supabase 기본 limit 1000개 + 오름차순 정렬로 최신 데이터 누락
- **해결**: `.limit(10000)` 추가 및 내림차순 정렬로 변경

## Changes

- `src/hooks/useServices.ts`: 쿼리에 limit 확장 및 정렬 순서 변경
- `docs/done/2_data_bug.md`: 버그 분석 문서 업데이트 (실제 원인 반영)

## Test

- [x] 로컬에서 Dashboard 페이지 확인 - 12/27, 28 데이터 표시됨
- [x] 로컬에서 History 페이지 확인 - 12/27, 28 초록색으로 표시됨

🤖 Generated with [Claude Code](https://claude.ai/code)