### PR TITLE
feat: deploy-preview 빌드 스킵 설정 추가

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   command = "npm run build"
   publish = ".next"
+  ignore = "/bin/bash -c '[[ \"$CONTEXT\" == \"deploy-preview\" ]] && exit 0 || exit 1'"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- Netlify deploy-preview 컨텍스트에서 불필요한 빌드를 스킵하도록 `ignore` 설정 추가
- production 빌드는 기존과 동일하게 정상 진행

## Test plan
- [ ] Netlify production 빌드 정상 동작 확인
- [ ] PR 생성 시 deploy-preview 빌드가 스킵되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)