### PR TITLE
fix: UPTIME 90 DAY 모바일에서 가용시간 % 컬럼 잘림 수정

### DIFF
--- a/src/components/UptimeGrid.tsx
+++ b/src/components/UptimeGrid.tsx
@@ -99,7 +99,7 @@ export default function UptimeHeatmap({
               className="heatmap-row"
               style={{
                 display: 'grid',
-                gridTemplateColumns: '160px 1fr 70px',
+                gridTemplateColumns: '160px minmax(0, 1fr) 70px',
                 gap: 14,
                 alignItems: 'center',
               }}
@@ -115,7 +115,7 @@ export default function UptimeHeatmap({
               >
                 {svc.name}
               </div>
-              <div style={{ display: 'flex', gap: 2, height: 26 }}>
+              <div className="heatmap-strip" style={{ display: 'flex', gap: 2, height: 26, minWidth: 0 }}>
                 {dates.map((d, di) => {
                   const summ = summaryByDate
                     .get(toLocalDateString(d))
@@ -125,6 +125,7 @@ export default function UptimeHeatmap({
                     return (
                       <div
                         key={di}
+                        className="heatmap-cell"
                         style={{
                           flex: 1,
                           minWidth: 4,
@@ -138,6 +139,7 @@ export default function UptimeHeatmap({
                   return (
                     <div
                       key={di}
+                      className="heatmap-cell"
                       title={`${d.toLocaleDateString('ko-KR')} · ${status} · ${summ?.avg_response_time ?? '—'}ms`}
                       style={{
                         flex: 1,
@@ -172,7 +174,13 @@ export default function UptimeHeatmap({
       <style>{`
         @media (max-width: 640px) {
           .heatmap-row {
-            grid-template-columns: 100px 1fr 60px !important;
+            grid-template-columns: 100px minmax(0, 1fr) 60px !important;
+          }
+          .heatmap-strip {
+            gap: 1px !important;
+          }
+          .heatmap-cell {
+            min-width: 1px !important;
           }
         }
       `}</style>


### PR DESCRIPTION
## Summary
모바일(390px) 뷰포트에서 UPTIME · 90 DAY 패널의 우측 가용시간 % 컬럼(96.67%, 100% 등)이 화면 밖으로 잘려 보이지 않던 문제 수정.

### 원인
`heatmap-row`의 grid-template-columns가 `160px 1fr 70px`이고 가운데 컬럼 안 90개 셀이 각각 `min-width: 4px` + `gap: 2px`로 intrinsic min-content가 538px. CSS Grid의 `1fr`은 자식의 min-content를 존중하므로 행 전체가 726px로 고정되어 모바일 뷰포트(390px) 초과. `body { overflow-x: hidden }` 때문에 가로 스크롤도 불가능해 % 컬럼이 영영 보이지 않음.

### 변경
- `gridTemplateColumns`에 `minmax(0, 1fr)` 적용 (desktop·mobile 모두) — grid track이 자식 min-content보다 작게 축소 가능하도록
- 날짜 strip flex 컨테이너에 `min-width: 0` 인라인 추가 — flex intrinsic min을 0으로 보고하여 grid track이 실제로 축소되도록 (이게 빠지면 minmax(0,1fr)만으로는 효과 없음)
- strip·cell에 클래스 부여(`heatmap-strip`, `heatmap-cell`)
- 모바일(`@media max-width: 640px`)에서 cell `min-width` 4px → 1px, gap 2px → 1px로 축소하여 90개 셀이 좁은 폭에 맞도록

### 검증 (DevTools mobile 390x844)
| | Before | After |
|---|---|---|
| `.heatmap-row` 너비 | 726px (overflow) | 276px (parent fit) |
| % 컬럼 우측 끝 좌표 | x=783 (off-screen) | x=333 (in 390 viewport) |
| 사용자가 % 보임 | ✗ | ✓ |

데스크톱(1280px)에서는 컬럼이 변동 없이 동일하게 표시됨 확인.

## Test plan
- [ ] 데스크톱(1280px+)에서 90일 히트맵과 % 모두 기존대로 표시되는지 확인
- [ ] iPhone SE(375px)/iPhone 14 Pro(390px)에서 모든 서비스 행의 % 값이 잘리지 않고 보이는지 확인
- [ ] iPad(768px) 등 중간 크기 뷰포트에서 레이아웃 깨짐 없는지 확인
- [ ] 다크 모드에서 셀 색상·간격 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)